### PR TITLE
Bump min IntelliJ version to 2022.3, suppress warning in ActionUpdateThread

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Changed
+
+- Change minimum supported IntelliJ version to 2022.3
+
 ## [0.1.4] - 2023-12-04
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,7 @@
 import org.jetbrains.grammarkit.tasks.GenerateLexerTask
 import org.jetbrains.grammarkit.tasks.GenerateParserTask
 import org.jetbrains.changelog.Changelog
-import org.jetbrains.kotlin.gradle.dsl.KotlinJvmCompile
+import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 
 val versionDetails: groovy.lang.Closure<com.palantir.gradle.gitversion.VersionDetails> by extra
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,8 @@ version = if (gitDetails.isCleanTag) {
     } + "-dev." + gitDetails.gitHash
 }
 
-java.sourceCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_17
+java.targetCompatibility = JavaVersion.VERSION_17
 
 repositories {
     mavenCentral()
@@ -74,7 +75,7 @@ task("generateParserTask", GenerateParserTask::class) {
 }
 
 intellij {
-    version = "2022.1"
+    version = "2022.3"
     sandboxDir = "tmp/sandbox"
 }
 
@@ -87,7 +88,7 @@ tasks.named("compileKotlin") {
 }
 
 tasks.withType<KotlinJvmCompile> {
-    kotlinOptions.jvmTarget = "11"
+    kotlinOptions.jvmTarget = "17"
 }
 
 sourceSets {
@@ -102,7 +103,7 @@ tasks.withType<Test> {
     useJUnitPlatform()
 }
 
-val intellijSinceBuild = "221"
+val intellijSinceBuild = "223"
 val intellijUntilBuild = ""
 
 tasks.patchPluginXml {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 
 # plugins
-kotlin = "1.6.20"
+kotlin = "1.7.0"
 gradleIntellijPlugin = "1.17.2"
 grammerKit = "2022.3.2.2"
 changelog = "2.2.0"
@@ -11,7 +11,6 @@ junit = "5.10.2"
 
 [libraries]
 
-kotlinStdlib = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib", version.ref = "kotlin" }
 # test only
 kotlinTest = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotlinTestJdk7 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk7", version.ref = "kotlin" }

--- a/src/main/java/com/google/idea/gn/actions/NewBuildFileAction.kt
+++ b/src/main/java/com/google/idea/gn/actions/NewBuildFileAction.kt
@@ -25,6 +25,8 @@ class NewBuildFileAction : AnAction(CAPTION, "", GnIcons.FILE) {
     return dir.virtualFile.findChild(GnFile.BUILD_FILE) == null
   }
 
+  override fun getActionUpdateThread(): ActionUpdateThread = ActionUpdateThread.BGT
+
   override fun update(e: AnActionEvent) {
     val dataContext = e.dataContext
     val presentation = e.presentation


### PR DESCRIPTION
Fixes https://github.com/google/intellij-gn-plugin/issues/38