### PR TITLE
Migrate to IntelliJ Platform Gradle Plugin 2.x from Gradle IntelliJ Plugin 1.x

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -40,22 +40,9 @@ jobs:
           cache-read-only: true
           gradle-home-cache-cleanup: true
 
-      - name: Set Plugin Verifier Home Dir
-        id: properties
-        run: |
-            echo "pluginVerifierHomeDir=~/.pluginVerifier" >> $GITHUB_OUTPUT
-
-      # Cache Plugin Verifier IDEs
-      - name: Setup Plugin Verifier IDEs Cache
-        uses: actions/cache@v4
-        with:
-          path: ${{ steps.properties.outputs.pluginVerifierHomeDir }}/ides
-          key: plugin-verifier-${{ hashFiles('build/listProductsReleases.txt') }}
-
       # Run Verify Plugin task and IntelliJ Plugin Verifier tool
       - name: Run Plugin Verification tasks
-        run: ./gradlew runPluginVerifier -Dplugin.verifier.home.dir=${{ steps.properties.outputs.pluginVerifierHomeDir }}
-
+        run: ./gradlew verifyPlugin
 
       # Collect Plugin Verifier Result
       - name: Collect Plugin Verifier Result

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ gradle-app.setting
 .gradletasknamecache<Paste>
 
 .idea
+.intellijPlatform

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+- Change minimum supported IntelliJ version to 2023.1
+
 ## [0.1.5] - 2024-04-06
 
 ### Changed

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,9 @@ intellijPlatform {
     pluginConfiguration {
         ideaVersion {
             sinceBuild.set(intellijSinceBuild)
-            untilBuild.set(intellijUntilBuild)
+            if (intellijUntilBuild.isNotBlank()) {
+                untilBuild.set(intellijUntilBuild)
+            }
         }
 
         val changelog = project.changelog // local variable for configuration cache compatibility

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -84,14 +84,29 @@ tasks.register("generateParserTask", GenerateParserTask::class) {
     purgeOldFiles = true
 }
 
+val intellijSinceBuild = "231"
+val intellijUntilBuild = ""
+
 intellijPlatform {
     sandboxContainer.set(file("tmp/sandbox"))
 
     pluginConfiguration {
         ideaVersion {
-            sinceBuild = "231"
-            untilBuild = ""
+            sinceBuild.set(intellijSinceBuild)
+            untilBuild.set(intellijUntilBuild)
         }
+
+        val changelog = project.changelog // local variable for configuration cache compatibility
+        changeNotes.set(providers.gradleProperty("intellijGnVersion").map { pluginVersion ->
+            with(changelog) {
+                renderItem(
+                    (getOrNull(pluginVersion) ?: getUnreleased())
+                        .withHeader(false)
+                        .withEmptySections(false),
+                    Changelog.OutputType.HTML,
+                )
+            }
+        })
     }
 }
 
@@ -133,26 +148,6 @@ sourceSets {
 
 tasks.withType<Test> {
     useJUnitPlatform()
-}
-
-val intellijSinceBuild = "231"
-val intellijUntilBuild = ""
-
-tasks.patchPluginXml {
-    sinceBuild = intellijSinceBuild
-    untilBuild = intellijUntilBuild
-    val changelog = project.changelog // local variable for configuration cache compatibility
-    // Get the latest available change notes from the changelog file
-    changeNotes = providers.gradleProperty("intellijGnVersion").map { pluginVersion ->
-        with(changelog) {
-            renderItem(
-                (getOrNull(pluginVersion) ?: getUnreleased())
-                    .withHeader(false)
-                    .withEmptySections(false),
-                Changelog.OutputType.HTML,
-            )
-        }
-    }
 }
 
 tasks.publishPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,7 @@ import org.jetbrains.changelog.Changelog
 import org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile
 import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
+
 val versionDetails: groovy.lang.Closure<com.palantir.gradle.gitversion.VersionDetails> by extra
 
 plugins {
@@ -107,6 +108,12 @@ intellijPlatform {
                 )
             }
         })
+    }
+
+    pluginVerification {
+        ides {
+            recommended()
+        }
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,12 +1,13 @@
 [versions]
 
 # plugins
-kotlin = "1.7.0"
-gradleIntellijPlugin = "1.17.3"
+kotlin = "1.8.0"
+gradleIntellijPlugin = "2.7.0"
 grammerKit = "2022.3.2.2"
 changelog = "2.2.0"
 gitVersion = "4.0.0"
 
+junit4 = "4.13.2"
 junit = "5.10.2"
 
 [libraries]
@@ -15,6 +16,7 @@ junit = "5.10.2"
 kotlinTest = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin" }
 kotlinTestJdk7 = { group = "org.jetbrains.kotlin", name = "kotlin-stdlib-jdk7", version.ref = "kotlin" }
 
+junit4 = { group = "junit", name = "junit", version.ref = "junit4" }
 junitBom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junitPlatformLauncher = { group = "org.junit.platform", name = "junit-platform-launcher" }
 junitJupiterEngine = { group = "org.junit.jupiter", name = "junit-jupiter-engine" }
@@ -23,7 +25,7 @@ jnintVintageEngine = { group = "org.junit.vintage", name = "junit-vintage-engine
 [plugins]
 
 kotlin =  { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
-gradleIntellijPlugin = { id = "org.jetbrains.intellij", version.ref = "gradleIntellijPlugin" }
+gradleIntellijPlugin = { id = "org.jetbrains.intellij.platform", version.ref = "gradleIntellijPlugin" }
 grammerKit = { id = "org.jetbrains.grammarkit", version.ref = "grammerKit" }
 changelog = { id = "org.jetbrains.changelog", version.ref = "changelog" }
 gitVersion = { id = "com.palantir.git-version", version.ref = "gitVersion" }


### PR DESCRIPTION
Upon migrating, the minimum IDE version had to be bumped from 2022.3 to 2023.1.
Although the documentation states that 2022.3 is still supported, an unexpected error was encountered when attempting to build the plugin with 2022.3.