### PR TITLE
Fix plugin verification for IntelliJ 2025.3+ compatibility

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -38,6 +38,7 @@ repositories {
 
 dependencies {
     intellijPlatform {
+        @Suppress("DEPRECATION")
         intellijIdeaCommunity("2023.1")
         testFramework(TestFrameworkType.Platform)
     }
@@ -114,7 +115,14 @@ intellijPlatform {
 
     pluginVerification {
         ides {
-            recommended()
+            // IC (IntelliJ IDEA Community) is no longer available starting from 2025.3 (build 253)
+            select {
+                sinceBuild.set(intellijSinceBuild)
+                untilBuild.set("252.*")
+            }
+
+            // TODO: Replace EAP with the release version when available
+            create("IU", "253.22441.33")
         }
     }
 }


### PR DESCRIPTION
- Replace `recommended()` with explicit IC/IU version selection
- Limit IC to 2025.2, add IU for 2025.3 EAP (unified distribution)
- Suppress deprecation warning for `intellijIdeaCommunity`